### PR TITLE
Update the UI text for to-dos

### DIFF
--- a/lib/task_spell_web/live/todo_item_live/from_component.ex
+++ b/lib/task_spell_web/live/todo_item_live/from_component.ex
@@ -59,7 +59,7 @@ defmodule TaskSpellWeb.TodoItemLive.FormComponent do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Todo Item updated successfully")
+         |> put_flash(:info, "To-do item updated successfully")
          |> push_navigate(to: socket.assigns.navigate)}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -74,7 +74,7 @@ defmodule TaskSpellWeb.TodoItemLive.FormComponent do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Todo Item created successfully")
+         |> put_flash(:info, "To-do item created successfully")
          |> push_navigate(to: socket.assigns.navigate)}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/task_spell_web/live/todo_item_live/show.ex
+++ b/lib/task_spell_web/live/todo_item_live/show.ex
@@ -33,7 +33,7 @@ defmodule TaskSpellWeb.TodoItemLive.Show do
 
     {:noreply,
     socket
-    |> put_flash(:info, "Todo Item successfully deleted")
+    |> put_flash(:info, "To-do Item successfully deleted")
     |> push_navigate(to: socket.assings.navigate)}
   end
 
@@ -42,6 +42,6 @@ defmodule TaskSpellWeb.TodoItemLive.Show do
     {:noreply, stream_insert(socket, :todo_items, todo_item)}
   end
 
-  defp page_title(:show), do: "Show Todo item"
-  defp page_title(:edit), do: "Edit Todo item"
+  defp page_title(:show), do: "Show To-do item"
+  defp page_title(:edit), do: "Edit To-do item"
 end

--- a/lib/task_spell_web/live/todo_item_live/show.html.heex
+++ b/lib/task_spell_web/live/todo_item_live/show.html.heex
@@ -32,5 +32,5 @@
   <:item title="Due at">{@todo_item.due_at}</:item>
 </.list>
 
-<.back navigate={~p"/todo_lists/#{@todo_item.todo_list_id}"}>Back to the Todo List</.back>
+<.back navigate={~p"/todo_lists/#{@todo_item.todo_list_id}"}>Back to the To-do List</.back>
 

--- a/lib/task_spell_web/live/todo_list_live/form_component.ex
+++ b/lib/task_spell_web/live/todo_list_live/form_component.ex
@@ -9,7 +9,6 @@ defmodule TaskSpellWeb.TodoListLive.FormComponent do
     <div>
       <.header>
         {@title}
-        <:subtitle>Use this form to manage Todo List records in your database.</:subtitle>
       </.header>
 
       <.simple_form
@@ -22,7 +21,7 @@ defmodule TaskSpellWeb.TodoListLive.FormComponent do
         <.input field={@form[:title]} type="text" label="Title" />
         <.input field={@form[:description]} type="textarea" label="Description" />
         <:actions>
-          <.button phx-disable-with="Saving...">Save Todo List</.button>
+          <.button phx-disable-with="Saving...">Save to-do list</.button>
         </:actions>
       </.simple_form>
     </div>
@@ -56,7 +55,7 @@ defmodule TaskSpellWeb.TodoListLive.FormComponent do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Todo List updated successfully")
+         |> put_flash(:info, "To-do list updated successfully")
          |> push_patch(to: socket.assigns.patch)}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -71,7 +70,7 @@ defmodule TaskSpellWeb.TodoListLive.FormComponent do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Todo List created successfully")
+         |> put_flash(:info, "To-do list created successfully")
          |> push_patch(to: socket.assigns.patch)}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/task_spell_web/live/todo_list_live/index.ex
+++ b/lib/task_spell_web/live/todo_list_live/index.ex
@@ -28,7 +28,7 @@ defmodule TaskSpellWeb.TodoListLive.Index do
 
   defp apply_action(socket, :index, _params) do
     socket
-    |> assign(:page_title, "Todo Lists")
+    |> assign(:page_title, "To-do Lists")
     |> assign(:todo_list, nil)
   end
 

--- a/lib/task_spell_web/live/todo_list_live/index.html.heex
+++ b/lib/task_spell_web/live/todo_list_live/index.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  Todo Lists
+  To-do Lists
   <:actions>
     <.link patch={~p"/todo_lists/new"}>
       <.button>New List</.button>

--- a/lib/task_spell_web/live/todo_list_live/show.html.heex
+++ b/lib/task_spell_web/live/todo_list_live/show.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  Todo List: {@todo_list.title}
+  To-do List: {@todo_list.title}
   <:subtitle>{@todo_list.description}</:subtitle>
   <:actions>
     <.link patch={~p"/todo_lists/#{@todo_list}/show/edit"} phx-click={JS.push_focus()}>
@@ -13,7 +13,7 @@
   Items
   <:actions>
     <.link patch={~p"/todo_lists/#{@todo_list.id}/todo_items/new"}>
-      <.button>New Todo Item</.button>
+      <.button>New To-do Item</.button>
     </.link>
   </:actions>
 </.header>
@@ -35,7 +35,7 @@
     </:action>
   </.table>
 
-<.back navigate={~p"/todo_lists"}>Back to Todo Lists</.back>
+<.back navigate={~p"/todo_lists"}>Back to To-do Lists</.back>
 
 <.modal :if={@live_action == :edit} id="todo_list-modal" show on_cancel={JS.patch(~p"/todo_lists/#{@todo_list}")}>
   <.live_component

--- a/lib/task_spell_web/router.ex
+++ b/lib/task_spell_web/router.ex
@@ -19,7 +19,7 @@ defmodule TaskSpellWeb.Router do
 
     get "/", PageController, :home
 
-    # Todo Lists Routes
+    # To-do Lists Routes
     live "/todo_lists", TodoListLive.Index, :index
     live "/todo_lists/new", TodoListLive.Index, :new
     live "/todo_lists/:id/edit", TodoListLive.Index, :edit
@@ -27,7 +27,7 @@ defmodule TaskSpellWeb.Router do
     live "/todo_lists/:id", TodoListLive.Show, :show
     live "/todo_lists/:id/show/edit", TodoListLive.Show, :edit
 
-    # Todo Items Routes
+    # To-do Items Routes
     live "/todo_items/:id", TodoItemLive.Show, :show
     live "/todo_lists/:todo_list_id/todo_items/new", TodoItemLive.Show, :new
     live "/todo_items/:id/show/edit", TodoItemLive.Show, :edit

--- a/test/task_spell_web/live/todo_list_live_test.exs
+++ b/test/task_spell_web/live/todo_list_live_test.exs
@@ -19,7 +19,7 @@ defmodule TaskSpellWeb.TodoListLiveTest do
     test "lists all todo_lists", %{conn: conn, todo_list: todo_list} do
       {:ok, _index_live, html} = live(conn, ~p"/todo_lists")
 
-      assert html =~ "Todo Lists"
+      assert html =~ "To-do Lists"
       assert html =~ todo_list.description
     end
 
@@ -42,7 +42,7 @@ defmodule TaskSpellWeb.TodoListLiveTest do
       assert_patch(index_live, ~p"/todo_lists")
 
       html = render(index_live)
-      assert html =~ "Todo List created successfully"
+      assert html =~ "To-do list created successfully"
       assert html =~ "some description"
     end
 
@@ -65,7 +65,7 @@ defmodule TaskSpellWeb.TodoListLiveTest do
       assert_patch(index_live, ~p"/todo_lists")
 
       html = render(index_live)
-      assert html =~ "Todo List updated successfully"
+      assert html =~ "To-do list updated successfully"
       assert html =~ "some updated description"
     end
 
@@ -106,7 +106,7 @@ defmodule TaskSpellWeb.TodoListLiveTest do
       assert_patch(show_live, ~p"/todo_lists/#{todo_list}")
 
       html = render(show_live)
-      assert html =~ "Todo List updated successfully"
+      assert html =~ "To-do list updated successfully"
       assert html =~ "some updated description"
     end
   end


### PR DESCRIPTION
Modified UI text for to-do's to make it grammatically correct in English, instead of using the programmers `todo`.